### PR TITLE
Portfolios can now be filtered with [rescue_portfolio filter=MY_SLUG]

### DIFF
--- a/includes/portfolio-shortcode.php
+++ b/includes/portfolio-shortcode.php
@@ -8,7 +8,9 @@ function rescue_portfolio_shortcode($atts=array()) {
 add_shortcode('rescue_portfolio', 'rescue_portfolio_shortcode');
 
 function rescue_portfolio_show($atts=array()) {
-
-     require (RESCUE_PORTFOLIO_TEMPLATE_DIR . "/includes/template.php");
+    if (isset($atts["filter"])) {
+        $filter_term_slug = $atts["filter"]; // will be used by template script
+    }
+    require (RESCUE_PORTFOLIO_TEMPLATE_DIR . "/includes/template.php");
      
 }

--- a/includes/template.php
+++ b/includes/template.php
@@ -62,19 +62,19 @@
             $theme_name = wp_get_theme(); // - v1.2
 
             // Query Our Database
-            $image_query_args = array( 'post_type' => 'portfolio', 'posts_per_page' =>'-1' );
+            $portfolio_query_args = array( 'post_type' => 'portfolio', 'posts_per_page' =>'-1' );
             if (!empty($filter_term_slug)) {
                 // tax_query takes an array of tax query arguments arrays
                 // see http://codex.wordpress.org/Class_Reference/WP_Query#Taxonomy_Parameters
-                $image_query_args["tax_query"] = array(
-                                                     array(
+                $portfolio_query_args["tax_query"] = array(
+                                                        array(
                                                             'taxonomy' => 'filter',
                                                             'field'    => 'slug',
                                                             'terms'    => $filter_term_slug, // make this an array for multiple terms
-                                                     )
-                                                 );
+                                                        )
+                                                     );
             }
-            $wpbp = new WP_Query($image_query_args);
+            $wpbp = new WP_Query($portfolio_query_args);
 
             // Begin The Loop
             if ($wpbp->have_posts()) : while ($wpbp->have_posts()) : $wpbp->the_post(); 

--- a/includes/template.php
+++ b/includes/template.php
@@ -64,7 +64,13 @@
             // Query Our Database
             $image_query_args = array( 'post_type' => 'portfolio', 'posts_per_page' =>'-1' );
             if (!empty($filter_term_slug)) {
-                $image_query_args["filter"] = $filter_term_slug;
+                $image_query_args["tax_query"] = array(
+                                                     array(
+                                                            'taxonomy' => 'filter',
+                                                            'field'    => 'slug',
+                                                            'terms'    => $filter_term_slug, // make this an array for multiple terms
+                                                     )
+                                                 );
             }
             $wpbp = new WP_Query($image_query_args);
 

--- a/includes/template.php
+++ b/includes/template.php
@@ -1,6 +1,6 @@
 <div class="rescue_portfolio">
-
-<div class="filter_wrap">
+<?php if (empty($filter_term_slug)) : // filter widget is needed ?>
+    <div class="filter_wrap">
 
         <ul class="clearfix">
 
@@ -51,19 +51,22 @@
               // print out each of the categories in our new format
               echo $term_list;
             }
-
-            $theme_name = wp_get_theme(); // - v1.2
-
           ?>
         </ul><!-- .filter -->
     </div><!-- .filter_wrap -->
+<?php endif; ?>
 
         <ul id="Grid" class="">
       
           <?php
-            
+            $theme_name = wp_get_theme(); // - v1.2
+
             // Query Our Database
-            $wpbp = new WP_Query(array( 'post_type' => 'portfolio', 'posts_per_page' =>'-1' ) ); 
+            $image_query_args = array( 'post_type' => 'portfolio', 'posts_per_page' =>'-1' );
+            if (!empty($filter_term_slug)) {
+                $image_query_args["filter"] = $filter_term_slug;
+            }
+            $wpbp = new WP_Query($image_query_args);
 
             // Begin The Loop
             if ($wpbp->have_posts()) : while ($wpbp->have_posts()) : $wpbp->the_post(); 

--- a/includes/template.php
+++ b/includes/template.php
@@ -64,6 +64,8 @@
             // Query Our Database
             $image_query_args = array( 'post_type' => 'portfolio', 'posts_per_page' =>'-1' );
             if (!empty($filter_term_slug)) {
+                // tax_query takes an array of tax query arguments arrays
+                // see http://codex.wordpress.org/Class_Reference/WP_Query#Taxonomy_Parameters
                 $image_query_args["tax_query"] = array(
                                                      array(
                                                             'taxonomy' => 'filter',

--- a/readme.txt
+++ b/readme.txt
@@ -22,7 +22,7 @@ When activated, this plugin adds a custom post type called 'Portfolio' to your W
 1. Upload the plugin to the `/wp-content/plugins/` directory
 2. Activate the plugin through the 'Plugins' menu in WordPress
 3. Create a new page (a 'Full Width' page works best), naming it whatever you'd like (ex. Gallery)
-4. Paste the portfolio's shortcode in that page's content area. The shortcode is [rescue_portfolio]
+4. Paste the portfolio's shortcode in that page's content area. The shortcode is [rescue_portfolio] or [rescue_portfolio filter=MY_SLUG]
 5. Create portfolio posts under 'Portfolio > Add Item' with a featured image, title, excerpt and away you go!
 
 === Frequently Asked Questions ===
@@ -30,6 +30,10 @@ When activated, this plugin adds a custom post type called 'Portfolio' to your W
 = Should I display the portfolio with a shortcode? =
 
 Yep, you should use the [rescue_portfolio] shortcode in a full width page.
+
+= Can I filter the included images to only those of a certain filter? =
+
+Just append filter=MY_SLUG to the shortcode. Like this [rescue_portfolio filter=MY_SLUG]. Currently only one filter can be chosen.
 
 = Where can I check out other themes and plugins by Rescue Themes? =
 


### PR DESCRIPTION
The filter widget (.filter_wrap) is now only rendered, when no filter is set.

If one is set, the `WP_Query` is extended with [tax_query parameters](http://codex.wordpress.org/Class_Reference/WP_Query#Taxonomy_Parameters).

Extending this to support multiple terms should be as easy as making `$filter_term_slug` an array. But I haven't tested that.

This very pull request was tested locally with PHP 5.5.9 and on a hoster's PHP 5.4.30.
